### PR TITLE
Remove VA non-.gov

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -14,7 +14,6 @@ USDA.NET,Federal Agency - Executive,U.S. Department of Agriculture,,Washington,D
 USMMA.EDU,Federal Agency - Executive,Department of Transportation,,Kings Point,NY,
 VACLOUD.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VAFTL.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
-VAGLAID.ORG,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VAMOBILE.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VAPULSE.NET,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VETERANSCRISISLINE.NET,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,


### PR DESCRIPTION
VA has asserted that vaglaid.org is not affiliated with the Department of Veterans Affairs.  See CYHYOPS-5839.