### PR TITLE
Remove VA domain

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -13,7 +13,6 @@ THEHEARTTRUTH.COM,Federal Agency - Executive,Department of Health and Human Serv
 USDA.NET,Federal Agency - Executive,U.S. Department of Agriculture,,Washington,DC,
 USMMA.EDU,Federal Agency - Executive,Department of Transportation,,Kings Point,NY,
 VACLOUD.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
-VAFTL.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VAMOBILE.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VAPULSE.NET,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VETERANSCRISISLINE.NET,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,


### PR DESCRIPTION
VA states the domain vaftl.us was removed from services. CYHYOPS-6178
