### PR TITLE
Remove 3DES Exception Marking for Some Agencies

### DIFF
--- a/3des-exception-agencies.csv
+++ b/3des-exception-agencies.csv
@@ -4,106 +4,106 @@ ABMC,American Battle Monuments Commission,
 ACHP,Advisory Council on Historic Preservation,
 ACUS,Administrative Conference of the United States,
 BGSF,Barry Goldwater Scholarship and Excellence in Education Foundation,
-CFA,Commission of Fine Arts,TRUE
+CFA,Commission of Fine Arts,
 CFPB,Consumer Financial Protection Bureau,
 CFTC,Commodity Futures Trading Commission,
-CIGIE,Council of the Inspectors General on Integrity and Efficiency,TRUE
-CNCS,Corporation for National and Community Service,TRUE
+CIGIE,Council of the Inspectors General on Integrity and Efficiency,
+CNCS,Corporation for National and Community Service,
 CPSC,Consumer Product Safety Commission,
 CSHIB,U.S. Chemical Safety and Hazard Investigation Board,
 CSOSA,Court Services and Offender Supervision Agency,
 DENALI,Denali Commission,
-DHS,Department of Homeland Security,TRUE
-DNFSB,Defense Nuclear Facilities Safety Board,TRUE
+DHS,Department of Homeland Security,
+DNFSB,Defense Nuclear Facilities Safety Board,
 DOC,Department of Commerce,TRUE
 DOD,Department of Defense,
 DOE,Department of Energy,TRUE
-DOI,Department of the Interior,TRUE
+DOI,Department of the Interior,
 DOJ,Department of Justice,TRUE
 DOL,Department of Labor,
 DOS,Department of State,TRUE
 DOT,Department of Transportation,
 EAC,Election Assistance Commission,
-ED,Department of Education,TRUE
-EEOC,Equal Employment Opportunity Commission,TRUE
+ED,Department of Education,
+EEOC,Equal Employment Opportunity Commission,
 EPA,Environmental Protection Agency,
-EXIM,Export-Import Bank of the United States,TRUE
+EXIM,Export-Import Bank of the United States,
 FASAB,Federal Accounting Standards Advisory Board,
 FCA,Farm Credit Administration,
 FCC,Federal Communications Commission,
 FCSIC,Farm Credit System Insurance Corporation,
 FDIC,Federal Deposit Insurance Corporation,
-FERC,Federal Energy Regulatory Commission,TRUE
+FERC,Federal Energy Regulatory Commission,
 FFIEC,Federal Financial Institutions Examination Council,
-FHFA,Federal Housing Finance Agency,TRUE
+FHFA,Federal Housing Finance Agency,
 FHFAOIG,"Federal Housing Finance Agency, Office of the Inspector General",
 FLRA,Federal Labor Relations Authority,
-FMC,Federal Maritime Commission,TRUE
+FMC,Federal Maritime Commission,
 FMCS,Federal Mediation and Conciliation Service,
 FMSHRC,Federal Mine Safety and Health Review Commission,
 FRB,Federal Reserve Board of Governors,
 FRTIB,Federal Retirement Thrift Investment Board,
 FTC,Federal Trade Commission,
-GCERC,Gulf Coast Ecosystem Restoration Council,TRUE
+GCERC,Gulf Coast Ecosystem Restoration Council,
 GSA,General Services Administration,TRUE
 HHS,Department of Health and Human Services,TRUE
 HHSOIG,"Department of Health and Human Services, Office of Inspector General",
-HSTSF,Harry S. Truman Scholarship Foundation,TRUE
+HSTSF,Harry S. Truman Scholarship Foundation,
 HUD,Department of Housing and Urban Development,TRUE
 HUDOIG,"Department of Housing and Urban Development, Office of the Inspector General",
-IAF,Inter-American Foundation,TRUE
+IAF,Inter-American Foundation,
 IJCUSC,International Joint Commission: United States and Canada,
 IMLS,Institute of Museum and Library Services,
 JMMFF,James Madison Memorial Fellowship Foundation,
 MCC,Millennium Challenge Corporation,
 MMC,Marine Mammal Commission,
-MSPB,Merit Systems Protection Board,TRUE
-NARA,National Archives and Records Administration,TRUE
+MSPB,Merit Systems Protection Board,
+NARA,National Archives and Records Administration,
 NASA,National Aeronautics and Space Administration,
 NCD,National Council on Disabiity,
-NCPC,National Capital Planning Commission,TRUE
+NCPC,National Capital Planning Commission,
 NCUA,National Credit Union Administration,
-NEA,National Endowment for the Arts,TRUE
-NEH,National Endowment for the Humanities,TRUE
+NEA,National Endowment for the Arts,
+NEH,National Endowment for the Humanities,
 NIGC,National Indian Gaming Commission,
-NLRB,National Labor Relations Board,TRUE
+NLRB,National Labor Relations Board,
 NMB,National Mediation Board,TRUE
 NRC,Nuclear Regulatory Commission,
 NSF,National Science Foundation,TRUE
-NTSB,National Transportation Safety Board,TRUE
-NWTRB,U.S. Nuclear Waste Technical Review Board,TRUE
+NTSB,National Transportation Safety Board,
+NWTRB,U.S. Nuclear Waste Technical Review Board,
 OGE,Office of Government Ethics,
 ONHIR,Office of Navajo and Hopi Indian Relocation,
-OPIC,Overseas Private Investment Corporation,TRUE
-OPM,Office of Personnel Management,TRUE
-OSC,Office of Special Counsel,TRUE
-OSHRC,Occupational Safety and Health Review Commission,TRUE
+OPIC,Overseas Private Investment Corporation,
+OPM,Office of Personnel Management,
+OSC,Office of Special Counsel,
+OSHRC,Occupational Safety and Health Review Commission,
 PBGC,Pension Benefit Guaranty Corporation,
 PC,Peace Corps,
 PCLOB,Privacy and Civil Liberties Oversight Board,
 PRC,Postal Regulatory Commission,
 PT,Presidio Trust,
 RRB,Railroad Retirement Board,
-SBA,Small Business Administration,TRUE
+SBA,Small Business Administration,
 SEC,Securities and Exchange Commission,
-SSA,Social Security Administration,TRUE
-SSAB,Social Security Advisory Board,TRUE
+SSA,Social Security Administration,
+SSAB,Social Security Advisory Board,
 SSS,Selective Service System,
 STATE-OIG,US Department of State Office of Inspector General,
-STB,Surface Transportation Board,TRUE
+STB,Surface Transportation Board,
 TVA,Tennessee Valley Authority,TRUE
-Treasury,Department of Treasury,TRUE
-UDALL,Morris K. Udall and Stewart L. Udall Foundation,TRUE
-USAB,United States Access Board,TRUE
-USADF,United States African Development Foundation,TRUE
-USAGM,United States Agency for Global Media,TRUE
+Treasury,Department of Treasury,
+UDALL,Morris K. Udall and Stewart L. Udall Foundation,
+USAB,United States Access Board,
+USADF,United States African Development Foundation,
+USAGM,United States Agency for Global Media,
 USAID,United States Agency for International Development,
-USCCR,United States Commission on Civil Rights,TRUE
+USCCR,United States Commission on Civil Rights,
 USDA,United States Department of Agriculture,TRUE
 USIBWC,United States International Boundary and Water Commission,
 USICH,United States Interagency Council on Homelessness,
-USITC,United States International Trade Commission,TRUE
+USITC,United States International Trade Commission,
 USPSOIG,"United States Postal Service, Office of Inspector General",
-USTDA,United States Trade and Development Agency,TRUE
+USTDA,United States Trade and Development Agency,
 USTR,Office of the United States Trade Representative,
-VA,Department of Veteran Affairs,TRUE
+VA,Department of Veteran Affairs,


### PR DESCRIPTION
Due to Microsoft having enabled the option to disable 3DES, many agencies originally requiring the exception have become compliant.  CyberDirectives reached out to agencies to confirm whether or not they still require the exception and, if so, to re-confirm their applicable vendor constraint.
