### PR TITLE
Add nccoe.org to DOC's scope

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -34,3 +34,4 @@ BRIDGINGFOUNDATION.ORG,Federal Agency - Executive,Japan-United States Friendship
 FRIENDSHIPBLOSSOMS.ORG,Federal Agency - Executive,Japan-United States Friendship Commission,,Washington,DC,
 BUILDBACKBETTER.GOV,Federal Agency – Executive,General Services Administration,,Washington,DC,
 WORKLIFE4YOU.COM,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
+NCCOE.ORG,Federal Agency - Executive,Department of Commerce,,Boulder,CO,


### PR DESCRIPTION
nccoe.org was provided to us so that it gets added to the DOC BOD 18-01 reports.  It redirects to https://www.nccoe.nist.gov/.  Thanks!