### PR TITLE
Remove vapulse.net

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -14,7 +14,6 @@ USDA.NET,Federal Agency - Executive,U.S. Department of Agriculture,,Washington,D
 USMMA.EDU,Federal Agency - Executive,Department of Transportation,,Kings Point,NY,
 VACLOUD.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VAMOBILE.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
-VAPULSE.NET,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VETERANSCRISISLINE.NET,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 USPREVENTIVESERVICESTASKFORCE.ORG,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 TSLMS.ORG,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,


### PR DESCRIPTION
VA no longer owns vapulse.net; see CYHYOPS-7366.  Please remove this non-.gov so that they no longer show up in VA's reports.