### PR TITLE
Add vaitcampus.com for VA BOD reports

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -34,3 +34,4 @@ FRIENDSHIPBLOSSOMS.ORG,Federal Agency - Executive,Japan-United States Friendship
 BUILDBACKBETTER.GOV,Federal Agency – Executive,General Services Administration,,Washington,DC,
 WORKLIFE4YOU.COM,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 NCCOE.ORG,Federal Agency - Executive,Department of Commerce,,Boulder,CO,
+VAITCAMPUS.COM,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,


### PR DESCRIPTION
VA has requested that we add vaitcampus.com to their HTTPS and Tmail reports.  I will also add the small handful of subdomains I found via a Google search of site:vaitcampus.com to the GSA's other websites list so they show up as well.