### PR TITLE
Add two VA non-.Govs

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -2066,3 +2066,5 @@ uscdccn.us,Federal Agency - Executive,Department of Health and Human Services,,W
 vetmed.wiki,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 vetmedinfo.net,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 vavmc.com,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
+myvaapps.com,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
+treatmentworksforvets.org,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,


### PR DESCRIPTION
VA has requested we add the following non-.govs to their BOD 18-01 reports: myvaapps.com, www.treatmentworksforvets.org, and www.vetsprevail.org.

Reviewing WhoIs info and the sites requested, please add myvaapps.com and treatmentworksforvets.org.  We do not believe that vetsprevail.org is owned by or managed specifically on the VA's behalf.