### PR TITLE
Remove aghealth.org

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -1949,7 +1949,6 @@ zipstation.us,Federal Agency - Executive,United States Postal Service,,Washingto
 tvs-cbp.com,Federal Agency - Executive,Department of Homeland Security,,Washington,DC,
 3dvcell.org,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 actagainstaids.org,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
-aghealth.org,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 ahrq-meps.com,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 ahrqstg.org,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 armystarrs.com,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,


### PR DESCRIPTION
HHS/NIH has stated: "The site was purchased by IMS on behalf of NCI. All rights have been relinquished and NCI has no control over the domain."  Removing since the domain is no longer owned by nor operated on behalf of HHS.