### PR TITLE
Remove 1 HHS/IHS Domain

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -2027,7 +2027,6 @@ nlmgiftshop.info,Federal Agency - Executive,Department of Health and Human Servi
 nlmgiftshop.net,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 nnlm.org,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 ocaihs.com,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
-ocaihs.us,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 opa-fpclinicdb.com,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 pccds-ln.org,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 phs-nurse.org,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,


### PR DESCRIPTION
## 🗣 Description ##

Remove `ocaihs.us`.

## 💭 Motivation and context ##

HHS/IHS has requested that we remove ocaihs.us from Trustymail and HTTPS reports. I verified that this domain is no longer owned by HHS nor IHS via whois, dig, and navigating to the website to verified the certificate ownership.

## 🧪 Testing ##

Automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
