### PR TITLE
Add three Non-.Gov Base Domains for OPM

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -2065,3 +2065,6 @@ nanc-chair.org,Federal Agency - Executive,Federal Communications Commission,,Was
 reassigned.us,Federal Agency - Executive,Federal Communications Commission,,Washington,DC,
 cdmdashboard.com,Federal Agency - Executive,Department of Homeland Security,,Washington,DC,
 cyberstorm8.com,Federal Agency - Executive,Department of Homeland Security,,Washington,DC,
+benefeds.com,Federal Agency - Executive,Office of Personnel Management,,Washington,DC,
+givecfc.org,Federal Agency - Executive,Office of Personnel Management,,Washington,DC,
+ltcfeds.com,Federal Agency - Executive,Office of Personnel Management,,Washington,DC,


### PR DESCRIPTION
OPM requested a handful of domains get added to their HTTPS/Trustymail reports. The additions here are some of the non-.gov base domains included in that request. Some others are still being vetted.