### PR TITLE
Add 3DES Exception Asterisk for USAID

### DIFF
--- a/3des-exception-agencies.csv
+++ b/3des-exception-agencies.csv
@@ -97,7 +97,7 @@ UDALL,Morris K. Udall and Stewart L. Udall Foundation,
 USAB,United States Access Board,
 USADF,United States African Development Foundation,
 USAGM,United States Agency for Global Media,
-USAID,United States Agency for International Development,
+USAID,United States Agency for International Development,TRUE
 USCCR,United States Commission on Civil Rights,
 USDA,United States Department of Agriculture,TRUE
 USIBWC,United States International Boundary and Water Commission,


### PR DESCRIPTION
USAID is now using a google mail server and falls under the scope of the Temporary Exception for 3DES. The Cyber Directives team was looped into this change and has no issues with us noting the exception for USAID in the Cybex Scorecard.