### PR TITLE
Add 1 Non-.gov TREAS domain

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -2065,6 +2065,6 @@ benefeds.com,Federal Agency - Executive,Office of Personnel Management,,Washingt
 givecfc.org,Federal Agency - Executive,Office of Personnel Management,,Washington,DC,
 ltcfeds.com,Federal Agency - Executive,Office of Personnel Management,,Washington,DC,
 eeocdata.org,Federal Agency - Executive,Equal Employment Opportunity Commission,,Washington,DC,
-convergeoperations.com, Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington, DC
-federalalight.com, Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington, DC
+convergeoperations.com,Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington,DC,
+federalalight.com,Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington,DC,
 tftc-istehdaf.org,Federal Agency - Executive,Department of the Treasury,,Washington,DC,

--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -2067,4 +2067,4 @@ ltcfeds.com,Federal Agency - Executive,Office of Personnel Management,,Washingto
 eeocdata.org,Federal Agency - Executive,Equal Employment Opportunity Commission,,Washington,DC,
 convergeoperations.com, Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington, DC
 federalalight.com, Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington, DC
-tftc-istehdaf.org,Federal Agency - Executive,Department of the Treasury,,Washington,DC
+tftc-istehdaf.org,Federal Agency - Executive,Department of the Treasury,,Washington,DC,

--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -2067,3 +2067,4 @@ ltcfeds.com,Federal Agency - Executive,Office of Personnel Management,,Washingto
 eeocdata.org,Federal Agency - Executive,Equal Employment Opportunity Commission,,Washington,DC,
 convergeoperations.com, Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington, DC
 federalalight.com, Federal Agency - Executive,Federal Retirement Thrift Investment Board,,Washington, DC
+tftc-istehdaf.org,Federal Agency - Executive,Department of the Treasury,,Washington,DC


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds one non-`.gov` TREAS domain.

## 💭 Motivation and context ##

TREAS has requested that we add `tftc-istehdaf.org` so that it shows up in their Trustymail and HTTPS reports. I verified it is not currently being picked up in the sources gathered by double checking for its presence in their report. I also received confirmation that this domain is owned and operated by Treasury.

## 🧪 Testing ##

Visual testing only.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.