### PR TITLE
Remove 2 HHS Domains

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -15,8 +15,6 @@ USMMA.EDU,Federal Agency - Executive,Department of Transportation,,Kings Point,N
 VACLOUD.US,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 VETERANSCRISISLINE.NET,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 USPREVENTIVESERVICESTASKFORCE.ORG,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
-PSOPPC.COM,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
-PSOPPC.NET,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 PSOPPC.ORG,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 GENOMEREFERENCE.ORG,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,
 INFORMATIONRX.ORG,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request removes the following 2 HHS domains from current-federal-non-dotgov.csv:
- psoppc.com
- psoppc.net

## 💭 Motivation and context ##

HHS has requested that we remove psoppc.com and psoppc.net so that they no longer show up in their Trustymail and HTTPS reports. I verified the domains as well as the IPs are no longer owned nor managed on the agencies behalf. Relates to https://github.com/cisagov/dotgov-data/pull/104

## 🧪 Testing ##
All automated tests pass.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All new and existing tests pass.

