### PR TITLE
Add IAF to 3DES Exception List

### DIFF
--- a/3des-exception-agencies.csv
+++ b/3des-exception-agencies.csv
@@ -51,7 +51,7 @@ HHSOIG,"Department of Health and Human Services, Office of Inspector General",
 HSTSF,Harry S. Truman Scholarship Foundation,
 HUD,Department of Housing and Urban Development,TRUE
 HUDOIG,"Department of Housing and Urban Development, Office of the Inspector General",
-IAF,Inter-American Foundation,
+IAF,Inter-American Foundation,TRUE
 IJCUSC,International Joint Commission: United States and Canada,
 IMLS,Institute of Museum and Library Services,
 JMMFF,James Madison Memorial Fellowship Foundation,


### PR DESCRIPTION
IAF uses Google mail servers and currently falls under the Temporary Exception for BOD 18-01. The Cyber Directives team has concurred in adding IAF to this list so that their relevant compliance score within the Cybex Scorecard shows the asterisk denoting coverage by the exception.