### PR TITLE
Remove vavmc.com domain

### DIFF
--- a/current-federal-non-dotgov.csv
+++ b/current-federal-non-dotgov.csv
@@ -1978,7 +1978,6 @@ vacloud.us,Federal Agency - Executive,Department of Veterans Affairs,,Washington
 vaeddm.com,Federal Agency - Executive,United States Postal Service,,Washington,DC,
 vaitcampus.com,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 valleypostoffice.com,Federal Agency - Executive,United States Postal Service,,Washington,DC,
-vavmc.com,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 vermontpostoffice.com,Federal Agency - Executive,United States Postal Service,,Washington,DC,
 veteranscrisisline.net,Federal Agency - Executive,Department of Veterans Affairs,,Washington,DC,
 vetmedinfo.net,Federal Agency - Executive,Department of Health and Human Services,,Washington,DC,


### PR DESCRIPTION
Remove vavmc.com from VA scope. VA has requested that we remove vavmc.com so that it no longer shows up in their Trustymail and HTTPS reports. Confirmed domain has been decommissioned and is no longer owned or associated with VA.


